### PR TITLE
Add chevron arrow to edge-arrows documentation

### DIFF
--- a/documentation/demos/edge-arrows/data.json
+++ b/documentation/demos/edge-arrows/data.json
@@ -39,7 +39,11 @@
   { "data": { "id": "n19" } },
   { "data": { "id": "e9", "source": "n18", "target": "n19", "arrow": "diamond" } },
 
-  { "data": { "id": "n20", "type": "none" } },
+  { "data": { "id": "n20", "type": "chevron" } },
   { "data": { "id": "n21" } },
-  { "data": { "id": "e10", "source": "n20", "target": "n21", "arrow": "none" } }
+  { "data": { "id": "e10", "source": "n20", "target": "n21", "arrow": "chevron" } },
+
+  { "data": { "id": "n22", "type": "none" } },
+  { "data": { "id": "n23" } },
+  { "data": { "id": "e11", "source": "n22", "target": "n23", "arrow": "none" } }
 ]


### PR DESCRIPTION
The chevron arrow was added to cytoscape.js in 2018 but has not been included in the online demo. 

Associated issues: #3148

The PR adds the arrow: "none" seems like a special case, so I have left "none" at the end of the page and made chevron the penultimate example.

**Checklist**

Author:

- [ ] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
